### PR TITLE
Additional info about the request parameter name

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,6 +301,10 @@ def request_object(request: Request):
     ...
 ```
 
+!!! info 
+    You can name the request parameter any way you like (`request`, `req`, `r`, etc.), 
+    as long as you keep the correct type annotation (that is, `blacksheep.Request`).
+
 This subject will be treated in more details in a different section.
 
 ### Handling responses


### PR DESCRIPTION
As far as I understand, thanks to the recent fixes it's now possible to use any parameter name for the `Request` object. I think it is worth mentioning.