### PR TITLE
Fit exception_handlers to exceptions_handlers

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -67,7 +67,7 @@ def crash_test():
 
 ### Configuring exceptions handlers
 
-The BlackSheep `Application` object has a `exception_handlers` dictionary that
+The BlackSheep `Application` object has a `exceptions_handlers` dictionary that
 defines how errors should be handled. When an exception happens while handling
 a web request and reaches the application, the application checks if there is a
 matching handler for that kind of exception. An exception handler is defined as


### PR DESCRIPTION
_Application_ class doesn't have _exception_handlers_, the right name is     _exceptions_handlers_
