### PR TITLE
Update `testing.md` with fixed code for pytest blacksheep testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -370,6 +370,7 @@ file to include fixtures definition to arrange tests for the web application:
 import asyncio
 
 import pytest
+import pytest_asyncio
 from blacksheep.testing import TestClient
 from server import app as app_server
 
@@ -381,14 +382,14 @@ def event_loop(request):
     loop.close()
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def api():
     await app_server.start()
     yield app_server
     await app_server.stop()
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def test_client(api):
     return TestClient(api)
 


### PR DESCRIPTION
This problem seems to come across with 3.11, don't exactly know the circumstances in why/which this error gets reported. 

```
test_test.py::test_create_and_get_todo FAILED                            [100%]
test_test.py:4 (test_create_and_get_todo)
test_client = <coroutine object test_client at 0x108f84520>

    @pytest.mark.asyncio
    async def test_create_and_get_todo(test_client: TestClient) -> None:
>       response = await test_client.get("/")
E       AttributeError: 'coroutine' object has no attribute 'get'

test_test.py:7: AttributeError
```

But with `pytest_asyncio.fixture` used instead of `pytest.fixture` it seems to work.

**Edit:**

[Example Repo](https://github.com/sinnwise/test_blacksheep_pytest